### PR TITLE
Improvements to the Local Records & Core Data provider

### DIFF
--- a/CHANGELOG-2.0.0.md
+++ b/CHANGELOG-2.0.0.md
@@ -3,6 +3,7 @@
 ## Fixes
 * Fixed #119 : Fixed all symfony commands requiring connection to the dedicated server. 
 * Fixed : Typo in addEventProcessor method of the application dispatcher.
+* Fixed #322 : Issue with lost events during eXpansion start. This caused at startup not to have local records for exemple.
 
 ## Features
 * Feature Added ingame configuration system. 
@@ -14,6 +15,8 @@
 * Feature : Improved performance of Vote Gui using script update.
 * Feature : Console output for enabled/disabled plugins is lighter and easier to read. Additional info is in logs.
 * Feature : Added chat command for donation.
+* Feature #321 : Plugins can now have multiple data provider dependency with a OR logic. So if one of the providers is enabled it will enable the plugin
+* Feature #177 : Local records window display race & lap records. 
 
 # 2.0.0.0-alpha3 (2018-02-24)
 ## Bug Fixes

--- a/src/eXpansion/Bundle/LocalRecords/ChatCommand/Records.php
+++ b/src/eXpansion/Bundle/LocalRecords/ChatCommand/Records.php
@@ -2,7 +2,7 @@
 
 
 namespace eXpansion\Bundle\LocalRecords\ChatCommand;
-use eXpansion\Bundle\LocalRecords\Plugins\BaseRecords;
+use eXpansion\Bundle\LocalRecords\Plugins\AllRecords;
 use eXpansion\Bundle\LocalRecords\Plugins\Gui\RecordsWindowFactory;
 use eXpansion\Framework\Core\Model\ChatCommand\AbstractChatCommand;
 use Symfony\Component\Console\Input\InputInterface;
@@ -19,27 +19,27 @@ class Records extends AbstractChatCommand
     /** @var RecordsWindowFactory */
     protected $recordsWindowFactory;
 
-    /** @var BaseRecords */
-    protected $recordsPlugin;
+    /** @var AllRecords */
+    protected $allRecords;
 
     /**
      * Records constructor.
      *
      * @param $command
      * @param array $aliases
-     * @param BaseRecords $recordsPlugin
+     * @param AllRecords $allRecords
      * @param RecordsWindowFactory $recordsWindowFactory
      */
     public function __construct(
         $command,
         array $aliases = [],
-        BaseRecords $recordsPlugin,
+        AllRecords $allRecords,
         RecordsWindowFactory $recordsWindowFactory
     ) {
         parent::__construct($command, $aliases);
 
         $this->recordsWindowFactory = $recordsWindowFactory;
-        $this->recordsPlugin = $recordsPlugin;
+        $this->allRecords = $allRecords;
     }
 
     /**
@@ -47,7 +47,7 @@ class Records extends AbstractChatCommand
      */
     public function execute($login, InputInterface $input)
     {
-        $this->recordsWindowFactory->setRecordsData($this->recordsPlugin->getRecordsHandler()->getRecords());
+        $this->recordsWindowFactory->setRecordsData($this->allRecords->getMapRecords());
         $this->recordsWindowFactory->create($login);
     }
 }

--- a/src/eXpansion/Bundle/LocalRecords/DataProviders/Listener/RecordsDataListener.php
+++ b/src/eXpansion/Bundle/LocalRecords/DataProviders/Listener/RecordsDataListener.php
@@ -3,6 +3,7 @@
 namespace eXpansion\Bundle\LocalRecords\DataProviders\Listener;
 
 use eXpansion\Bundle\LocalRecords\Model\Record;
+use eXpansion\Bundle\LocalRecords\Plugins\BaseRecords;
 
 /**
  * Interface RecordsDataListener
@@ -17,44 +18,48 @@ interface RecordsDataListener
      *
      * @param Record[] $records
      */
-    public function onLocalRecordsLoaded($records);
+    public function onLocalRecordsLoaded($records, BaseRecords $baseRecords);
 
     /**
      * Called when a player finishes map for the very first time (basically first record).
      *
-     * @param Record   $record
-     * @param Record[] $records
-     * @param          $position
+     * @param Record        $record
+     * @param Record[]      $records
+     * @param               $position
+     * @param BaseRecords $baseRecords
      */
-    public function onLocalRecordsFirstRecord(Record $record, $records, $position);
+    public function onLocalRecordsFirstRecord(Record $record, $records, $position, BaseRecords $baseRecords);
 
     /**
      * Called when a player finishes map and does same time as before.
      *
-     * @param Record   $record
-     * @param Record   $oldRecord
-     * @param Record[] $records
+     * @param Record        $record
+     * @param Record        $oldRecord
+     * @param Record[]      $records
+     * @param BaseRecords $baseRecords
      */
-    public function onLocalRecordsSameScore(Record $record, Record $oldRecord, $records);
+    public function onLocalRecordsSameScore(Record $record, Record $oldRecord, $records, BaseRecords $baseRecords);
 
     /**
      * Called when a player finishes map with better time and has better position.
      *
-     * @param Record   $record
-     * @param Record   $oldRecord
-     * @param Record[] $records
-     * @param int      $position
-     * @param int      $oldPosition
+     * @param Record        $record
+     * @param Record        $oldRecord
+     * @param Record[]      $records
+     * @param int           $position
+     * @param int           $oldPosition
+     * @param BaseRecords $baseRecords
      */
-    public function onLocalRecordsBetterPosition(Record $record, Record $oldRecord, $records, $position, $oldPosition);
+    public function onLocalRecordsBetterPosition(Record $record, Record $oldRecord, $records, $position, $oldPosition, BaseRecords $baseRecords);
 
     /**
      * Called when a player finishes map with better time but keeps same position.
      *
-     * @param Record   $record
-     * @param Record   $oldRecord
-     * @param Record[] $records
-     * @param          $position
+     * @param Record        $record
+     * @param Record        $oldRecord
+     * @param Record[]      $records
+     * @param               $position
+     * @param BaseRecords $baseRecords
      */
-    public function onLocalRecordsSamePosition(Record $record, Record $oldRecord, $records, $position);
+    public function onLocalRecordsSamePosition(Record $record, Record $oldRecord, $records, $position, BaseRecords $baseRecords);
 }

--- a/src/eXpansion/Bundle/LocalRecords/DataProviders/RecordsDataProvider.php
+++ b/src/eXpansion/Bundle/LocalRecords/DataProviders/RecordsDataProvider.php
@@ -4,6 +4,8 @@ namespace eXpansion\Bundle\LocalRecords\DataProviders;
 
 use eXpansion\Bundle\LocalRecords\Services\RecordHandler;
 use eXpansion\Framework\Core\DataProviders\AbstractDataProvider;
+use eXpansion\Framework\Core\Plugins\StatusStoredPluginInterface;
+use eXpansion\Framework\Core\Plugins\StatusStoredPluginTrait;
 
 /**
  * Class RecordsDataProvider
@@ -11,11 +13,19 @@ use eXpansion\Framework\Core\DataProviders\AbstractDataProvider;
  * @package eXpansion\Bundle\LocalRecords\DataProviders;
  * @author  oliver de Cramer <oliverde8@gmail.com>
  */
-class RecordsDataProvider extends AbstractDataProvider
+class RecordsDataProvider extends AbstractDataProvider implements StatusStoredPluginInterface
 {
+    use StatusStoredPluginTrait;
+
     public function onRecordsLoaded($params)
     {
-        $this->dispatch('onLocalRecordsLoaded', [$params[RecordHandler::COL_RECORDS]]);
+        $this->dispatch(
+            'onLocalRecordsLoaded',
+            [
+                $params[RecordHandler::COL_RECORDS],
+                $params[RecordHandler::COL_PLUGIN],
+            ]
+        );
     }
 
     public function onFirstRecord($params)
@@ -26,6 +36,7 @@ class RecordsDataProvider extends AbstractDataProvider
                 $params[RecordHandler::COL_RECORD],
                 $params[RecordHandler::COL_RECORDS],
                 $params[RecordHandler::COL_POS],
+                $params[RecordHandler::COL_PLUGIN],
             ]
         );
     }
@@ -38,6 +49,7 @@ class RecordsDataProvider extends AbstractDataProvider
                 $params[RecordHandler::COL_RECORD],
                 $params[RecordHandler::COL_OLD_RECORD],
                 $params[RecordHandler::COL_RECORDS],
+                $params[RecordHandler::COL_PLUGIN],
             ]
         );
     }
@@ -52,6 +64,7 @@ class RecordsDataProvider extends AbstractDataProvider
                 $params[RecordHandler::COL_RECORDS],
                 $params[RecordHandler::COL_POS],
                 $params[RecordHandler::COL_OLD_POS],
+                $params[RecordHandler::COL_PLUGIN],
             ]
         );
     }
@@ -65,8 +78,8 @@ class RecordsDataProvider extends AbstractDataProvider
                 $params[RecordHandler::COL_OLD_RECORD],
                 $params[RecordHandler::COL_RECORDS],
                 $params[RecordHandler::COL_POS],
+                $params[RecordHandler::COL_PLUGIN],
             ]
         );
     }
-
 }

--- a/src/eXpansion/Bundle/LocalRecords/Plugins/AllRecords.php
+++ b/src/eXpansion/Bundle/LocalRecords/Plugins/AllRecords.php
@@ -1,0 +1,100 @@
+<?php
+
+
+namespace eXpansion\Bundle\LocalRecords\Plugins;
+
+use eXpansion\Bundle\LocalRecords\DataProviders\Listener\RecordsDataListener;
+use eXpansion\Bundle\LocalRecords\Model\Record;
+use eXpansion\Bundle\LocalRecords\Services\RecordHandler;
+use eXpansion\Framework\GameManiaplanet\DataProviders\Listener\ListenerInterfaceMpLegacyMap;
+use Maniaplanet\DedicatedServer\Structures\Map;
+
+/**
+ * Class AllRecords
+ *
+ * @package eXpansion\Bundle\LocalRecords\Plugins;
+ * @author  oliver de Cramer <oliverde8@gmail.com>
+ */
+class AllRecords implements RecordsDataListener, ListenerInterfaceMpLegacyMap
+{
+    /** @var RecordHandler[] */
+    protected $recordHandlers;
+
+    public function getMapRecords()
+    {
+        $mergedRecords = [];
+
+        foreach ($this->recordHandlers[1]->getRecords() as $i => $record) {
+            $recordData = [
+                'position' => $i + 1,
+                'player' => $record->getPlayer(),
+                'record' => ['1' => $record],
+            ];
+
+            foreach ($this->recordHandlers as $nbLaps => $recordHandler) {
+                if ($nbLaps != 1) {
+                    $position = $recordHandler->getPlayerPosition($record->getPlayer()->getLogin());
+                    if ($position !== null) {
+                        $recordData["record"][$nbLaps] = $recordHandler->getPlayerRecord($record->getPlayer()->getLogin());
+                        $recordData["record"]["other"] = $recordHandler->getPlayerRecord($record->getPlayer()->getLogin());
+                    }
+                }
+            }
+
+            $mergedRecords[] = $recordData;
+        }
+
+        return $mergedRecords;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function onBeginMap(Map $map)
+    {
+        $this->recordHandlers = [];
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function onLocalRecordsLoaded($records, BaseRecords $baseRecords)
+    {
+        $this->recordHandlers[$baseRecords->getRecordsHandler()->getCurrentNbLaps()] = $baseRecords->getRecordsHandler();
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function onEndMap(Map $map)
+    {
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function onLocalRecordsFirstRecord(Record $record, $records, $position, BaseRecords $baseRecords)
+    {
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function onLocalRecordsSameScore(Record $record, Record $oldRecord, $records, BaseRecords $baseRecords)
+    {
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function onLocalRecordsBetterPosition(Record $record, Record $oldRecord, $records, $position, $oldPosition, BaseRecords $baseRecords)
+    {
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function onLocalRecordsSamePosition(Record $record, Record $oldRecord, $records, $position, BaseRecords $baseRecords)
+    {
+    }
+}

--- a/src/eXpansion/Bundle/LocalRecords/Plugins/BaseRecords.php
+++ b/src/eXpansion/Bundle/LocalRecords/Plugins/BaseRecords.php
@@ -243,6 +243,7 @@ class BaseRecords implements ListenerInterfaceMpScriptMap, ListenerInterfaceMpSc
         $event = $this->eventPrefix.'.'.$eventData['event'];
         unset($eventData['event']);
 
+        $eventData[RecordHandler::COL_PLUGIN] = $this;
         $this->dispatcher->dispatch($event, [$eventData]);
     }
 

--- a/src/eXpansion/Bundle/LocalRecords/Plugins/ChatNotification.php
+++ b/src/eXpansion/Bundle/LocalRecords/Plugins/ChatNotification.php
@@ -58,12 +58,9 @@ class ChatNotification implements RecordsDataListener
     }
 
     /**
-     * Called when local records are loaded.
-     *
-     * @param Record[] $records
-     * @throws \Propel\Runtime\Exception\PropelException
+     * @inheritdoc
      */
-    public function onLocalRecordsLoaded($records)
+    public function onLocalRecordsLoaded($records, BaseRecords $baseRecords)
     {
         if (!empty($records)) {
             $firstRecord = $records[0];
@@ -88,45 +85,25 @@ class ChatNotification implements RecordsDataListener
     }
 
     /**
-     * Called when a player finishes map for the very first time (basically first record).
-     *
-     * @param Record   $record
-     * @param Record[] $records
-     * @param int      $position
-     * @throws \Propel\Runtime\Exception\PropelException
+     * @inheritdoc
      */
-    public function onLocalRecordsFirstRecord(Record $record, $records, $position)
+    public function onLocalRecordsFirstRecord(Record $record, $records, $position, BaseRecords $baseRecords)
     {
         $this->messageFirstPlaceNew($record);
     }
 
     /**
-     * Called when a player finishes map and does same time as before.
-     *
-     * @param Record   $record
-     * @param Record   $oldRecord
-     * @param Record[] $records
-     *
-     * @return void
+     * @inheritdoc
      */
-    public function onLocalRecordsSameScore(Record $record, Record $oldRecord, $records)
+    public function onLocalRecordsSameScore(Record $record, Record $oldRecord, $records, BaseRecords $baseRecords)
     {
         // Nothing.
     }
 
     /**
-     * Called when a player finishes map with better time and has better position.
-     *
-     * @param Record   $record
-     * @param Record   $oldRecord
-     * @param Record[] $records
-     * @param int      $position
-     * @param int      $oldPosition
-     *
-     * @return void
-     * @throws \Propel\Runtime\Exception\PropelException
+     * @inheritdoc
      */
-    public function onLocalRecordsBetterPosition(Record $record, Record $oldRecord, $records, $position, $oldPosition)
+    public function onLocalRecordsBetterPosition(Record $record, Record $oldRecord, $records, $position, $oldPosition, BaseRecords $baseRecords)
     {
         if ($position == 1 && $oldPosition == null) {
             $this->messageFirstPlaceNew($record);
@@ -172,17 +149,9 @@ class ChatNotification implements RecordsDataListener
     }
 
     /**
-     * Called when a player finishes map with better time but keeps same position.
-     *
-     * @param Record   $record
-     * @param Record   $oldRecord
-     * @param Record[] $records
-     * @param          $position
-     *
-     * @return void
-     * @throws \Propel\Runtime\Exception\PropelException
+     * @inheritdoc
      */
-    public function onLocalRecordsSamePosition(Record $record, Record $oldRecord, $records, $position)
+    public function onLocalRecordsSamePosition(Record $record, Record $oldRecord, $records, $position, BaseRecords $baseRecords)
     {
         // Check to who to send.
         $to = null;

--- a/src/eXpansion/Bundle/LocalRecords/Plugins/Gui/RecordsWindowFactory.php
+++ b/src/eXpansion/Bundle/LocalRecords/Plugins/Gui/RecordsWindowFactory.php
@@ -88,7 +88,13 @@ class RecordsWindowFactory extends WindowFactory
             )->addTextColumn(
                 'score',
                 'expansion_local_records.gui.race.window.column.score',
-                '3',
+                '2',
+                true,
+                true
+            )->addTextColumn(
+                'score_race',
+                'expansion_local_records.gui.race.window.column.score_race',
+                '2',
                 true,
                 true
             )->addTextColumn(
@@ -129,19 +135,19 @@ class RecordsWindowFactory extends WindowFactory
      */
     protected function getRecordsData()
     {
-        /** @var Record[] $recordsData */
         $recordsData = [];
-        /**
-         * @var  $i
-         * @var Record $record
-         */
         foreach ($this->recordsData as $i => $record) {
             $recordsData[] = [
-                'position' => $i + 1,
-                'nickname' => $record->getPlayer()->getNickname(),
-                'login' => $record->getPlayer()->getLogin(),
-                'score' => $this->timeFormatter->timeToText($record->getScore(), true),
+                'position' => $record['position'],
+                'nickname' => $record['player']->getNickname(),
+                'login' => $record['player']->getLogin(),
+                'score' => $this->timeFormatter->timeToText($record['record']["1"]->getScore(), true),
+                'score_race' => "<Not compatible>",
             ];
+
+            if (isset($record['record']["other"])) {
+                $record["score_race"] = $this->timeFormatter->timeToText($record['record']["other"]->getScore(), true);
+            }
         }
 
         return $recordsData;

--- a/src/eXpansion/Bundle/LocalRecords/Resources/config/chat_commands.yml
+++ b/src/eXpansion/Bundle/LocalRecords/Resources/config/chat_commands.yml
@@ -5,7 +5,6 @@ services:
         arguments:
           $command: records
           $aliases: ['recs']
-          $recordsPlugin: '@expansion.local_records.plugins.race_records'
 
     eXpansion.local_records.plugins.chat_commands.records:
         class: eXpansion\Framework\Core\Model\ChatCommand\ChatCommandPlugin
@@ -14,4 +13,4 @@ services:
                 - '@eXpansion\Bundle\LocalRecords\ChatCommand\Records'
         tags:
             - {name: 'expansion.plugin', data_provider: 'expansion.chat_command_data'}
-            - {name: 'expansion.plugin.parent', parent: 'expansion.local_records.plugins.race_records'}
+            - {name: 'expansion.plugin.parent', parent: 'eXpansion\Bundle\LocalRecords\Plugins\AllRecords'}

--- a/src/eXpansion/Bundle/LocalRecords/Resources/config/services.yml
+++ b/src/eXpansion/Bundle/LocalRecords/Resources/config/services.yml
@@ -6,6 +6,13 @@ services:
     eXpansion\Bundle\LocalRecords\Model\RecordQueryBuilder:
         class: eXpansion\Bundle\LocalRecords\Model\RecordQueryBuilder
 
+    eXpansion\Bundle\LocalRecords\Plugins\AllRecords:
+        class: eXpansion\Bundle\LocalRecords\Plugins\AllRecords
+        tags:
+          - {name: 'expansion.plugin', data_provider: 'expansion.local_records.race|expansion.local_records.lap'}
+          - {name: 'expansion.plugin', data_provider: 'mp.legacy.map'}
+
+
     eXpansion\Bundle\LocalRecords\Plugins\MenuItems:
         class: eXpansion\Bundle\LocalRecords\Plugins\MenuItems
         tags:

--- a/src/eXpansion/Bundle/LocalRecords/Resources/translations/messages.en.yml
+++ b/src/eXpansion/Bundle/LocalRecords/Resources/translations/messages.en.yml
@@ -42,7 +42,8 @@ expansion_local_records:
         title: 'Local Records'
         column:
           position: '#'
-          score: 'Time'
+          score: 'Lap Time'
+          score_race: 'Race Time'
           nickname: 'NickName'
           login: 'Login'
 

--- a/src/eXpansion/Bundle/LocalRecords/Services/RecordHandler.php
+++ b/src/eXpansion/Bundle/LocalRecords/Services/RecordHandler.php
@@ -91,6 +91,14 @@ class RecordHandler
     }
 
     /**
+     * @return int
+     */
+    public function getCurrentNbLaps(): int
+    {
+        return $this->currentNbLaps;
+    }
+
+    /**
      * @return Record[]
      */
     public function getRecords()

--- a/src/eXpansion/Bundle/LocalRecords/Services/RecordHandler.php
+++ b/src/eXpansion/Bundle/LocalRecords/Services/RecordHandler.php
@@ -41,6 +41,7 @@ class RecordHandler
     const COL_POS = 'position';
     const COL_OLD_POS = 'old_position';
     const COL_RECORDS = 'records';
+    const COL_PLUGIN = 'plugin';
 
     /** @var ConfigInterface */
     protected $nbRecords;

--- a/src/eXpansion/Bundle/WidgetBestCheckpoints/Plugins/BestCheckpoints.php
+++ b/src/eXpansion/Bundle/WidgetBestCheckpoints/Plugins/BestCheckpoints.php
@@ -4,6 +4,7 @@ namespace eXpansion\Bundle\WidgetBestCheckpoints\Plugins;
 
 use eXpansion\Bundle\LocalRecords\DataProviders\Listener\RecordsDataListener;
 use eXpansion\Bundle\LocalRecords\Model\Record;
+use eXpansion\Bundle\LocalRecords\Plugins\BaseRecords;
 use eXpansion\Bundle\WidgetBestCheckpoints\Plugins\Gui\BestCheckpointsWidgetFactory;
 use eXpansion\Bundle\WidgetBestCheckpoints\Plugins\Gui\UpdaterWidgetFactory;
 use eXpansion\Framework\Core\Model\UserGroups\Group;
@@ -86,7 +87,7 @@ class BestCheckpoints implements StatusAwarePluginInterface, RecordsDataListener
      *
      * @param Record[] $records
      */
-    public function onLocalRecordsLoaded($records)
+    public function onLocalRecordsLoaded($records, BaseRecords $recordHandler)
     {
         if (count($records) > 0) {
             $this->updater->setLocalRecord($records[0]->getCheckpoints());
@@ -102,7 +103,7 @@ class BestCheckpoints implements StatusAwarePluginInterface, RecordsDataListener
      * @param Record[] $records
      * @param          $position
      */
-    public function onLocalRecordsFirstRecord(Record $record, $records, $position)
+    public function onLocalRecordsFirstRecord(Record $record, $records, $position, BaseRecords $recordHandler)
     {
         $this->updater->setLocalRecord($record->getCheckpoints());
     }
@@ -114,7 +115,7 @@ class BestCheckpoints implements StatusAwarePluginInterface, RecordsDataListener
      * @param Record   $oldRecord
      * @param Record[] $records
      */
-    public function onLocalRecordsSameScore(Record $record, Record $oldRecord, $records)
+    public function onLocalRecordsSameScore(Record $record, Record $oldRecord, $records, BaseRecords $recordHandler)
     {
 
     }
@@ -128,7 +129,7 @@ class BestCheckpoints implements StatusAwarePluginInterface, RecordsDataListener
      * @param int      $position
      * @param int      $oldPosition
      */
-    public function onLocalRecordsBetterPosition(Record $record, Record $oldRecord, $records, $position, $oldPosition)
+    public function onLocalRecordsBetterPosition(Record $record, Record $oldRecord, $records, $position, $oldPosition, BaseRecords $recordHandler)
     {
         if ($position == 1) {
             $this->updater->setLocalRecord($record->getCheckpoints());
@@ -143,7 +144,7 @@ class BestCheckpoints implements StatusAwarePluginInterface, RecordsDataListener
      * @param Record[] $records
      * @param          $position
      */
-    public function onLocalRecordsSamePosition(Record $record, Record $oldRecord, $records, $position)
+    public function onLocalRecordsSamePosition(Record $record, Record $oldRecord, $records, $position, BaseRecords $recordHandler)
     {
         if ($position == 1) {
             $this->updater->setLocalRecord($record->getCheckpoints());

--- a/src/eXpansion/Bundle/WidgetBestCheckpoints/Plugins/BestCheckpoints.php
+++ b/src/eXpansion/Bundle/WidgetBestCheckpoints/Plugins/BestCheckpoints.php
@@ -86,8 +86,12 @@ class BestCheckpoints implements StatusAwarePluginInterface, RecordsDataListener
      *
      * @param Record[] $records
      */
-    public function onLocalRecordsLoaded($records, BaseRecords $recordHandler)
+    public function onLocalRecordsLoaded($records, BaseRecords $baseRecords)
     {
+        if (!$this->checkRecordPlugin($baseRecords)) {
+            return;
+        }
+
         if (count($records) > 0) {
             $this->updater->setLocalRecord($records[0]->getCheckpoints());
         } else {
@@ -102,8 +106,12 @@ class BestCheckpoints implements StatusAwarePluginInterface, RecordsDataListener
      * @param Record[] $records
      * @param          $position
      */
-    public function onLocalRecordsFirstRecord(Record $record, $records, $position, BaseRecords $recordHandler)
+    public function onLocalRecordsFirstRecord(Record $record, $records, $position, BaseRecords $baseRecords)
     {
+        if (!$this->checkRecordPlugin($baseRecords)) {
+            return;
+        }
+
         $this->updater->setLocalRecord($record->getCheckpoints());
     }
 
@@ -114,7 +122,7 @@ class BestCheckpoints implements StatusAwarePluginInterface, RecordsDataListener
      * @param Record   $oldRecord
      * @param Record[] $records
      */
-    public function onLocalRecordsSameScore(Record $record, Record $oldRecord, $records, BaseRecords $recordHandler)
+    public function onLocalRecordsSameScore(Record $record, Record $oldRecord, $records, BaseRecords $baseRecords)
     {
 
     }
@@ -128,8 +136,12 @@ class BestCheckpoints implements StatusAwarePluginInterface, RecordsDataListener
      * @param int      $position
      * @param int      $oldPosition
      */
-    public function onLocalRecordsBetterPosition(Record $record, Record $oldRecord, $records, $position, $oldPosition, BaseRecords $recordHandler)
+    public function onLocalRecordsBetterPosition(Record $record, Record $oldRecord, $records, $position, $oldPosition, BaseRecords $baseRecords)
     {
+        if (!$this->checkRecordPlugin($baseRecords)) {
+            return;
+        }
+
         if ($position == 1) {
             $this->updater->setLocalRecord($record->getCheckpoints());
         }
@@ -143,13 +155,28 @@ class BestCheckpoints implements StatusAwarePluginInterface, RecordsDataListener
      * @param Record[] $records
      * @param          $position
      */
-    public function onLocalRecordsSamePosition(Record $record, Record $oldRecord, $records, $position, BaseRecords $recordHandler)
+    public function onLocalRecordsSamePosition(Record $record, Record $oldRecord, $records, $position, BaseRecords $baseRecords)
     {
+        if (!$this->checkRecordPlugin($baseRecords)) {
+            return;
+        }
+
         if ($position == 1) {
             $this->updater->setLocalRecord($record->getCheckpoints());
         }
     }
 
+    /**
+     * Check if we can use the data for this plugin.
+     *
+     * @param BaseRecords $baseRecords
+     *
+     * @return bool
+     */
+    protected function checkRecordPlugin(BaseRecords $baseRecords)
+    {
+        return $baseRecords->getRecordsHandler()->getCurrentNbLaps() == 1;
+    }
 
     /**
      * @param Map $map

--- a/src/eXpansion/Bundle/WidgetBestCheckpoints/Plugins/BestCheckpoints.php
+++ b/src/eXpansion/Bundle/WidgetBestCheckpoints/Plugins/BestCheckpoints.php
@@ -12,7 +12,6 @@ use eXpansion\Framework\Core\Plugins\StatusAwarePluginInterface;
 use eXpansion\Framework\Core\Services\DedicatedConnection\Factory;
 use eXpansion\Framework\Core\Storage\PlayerStorage;
 use eXpansion\Framework\GameManiaplanet\DataProviders\Listener\ListenerInterfaceMpLegacyMap;
-use Maniaplanet\DedicatedServer\Connection;
 use Maniaplanet\DedicatedServer\Structures\Map;
 
 

--- a/src/eXpansion/Bundle/WidgetBestCheckpoints/Resources/config/plugins.yml
+++ b/src/eXpansion/Bundle/WidgetBestCheckpoints/Resources/config/plugins.yml
@@ -6,7 +6,7 @@ services:
                 $players: '@expansion.framework.core.user_groups.players'
                 $allPlayers: '@expansion.framework.core.user_groups.all_players'
         tags:
-          - {name: 'expansion.plugin', data_provider: 'expansion.local_records.race'}
+          - {name: 'expansion.plugin', data_provider: 'expansion.local_records.race|expansion.local_records.lap'}
           - {name: 'expansion.plugin', data_provider: 'mp.legacy.map'}
 
     eXpansion\Bundle\WidgetBestCheckpoints\Plugins\Gui\BestCheckpointsWidgetFactory:

--- a/src/eXpansion/Bundle/WidgetBestRecords/Plugins/BestRecords.php
+++ b/src/eXpansion/Bundle/WidgetBestRecords/Plugins/BestRecords.php
@@ -4,6 +4,7 @@ namespace eXpansion\Bundle\WidgetBestRecords\Plugins;
 
 use eXpansion\Bundle\LocalRecords\DataProviders\Listener\RecordsDataListener;
 use eXpansion\Bundle\LocalRecords\Model\Record;
+use eXpansion\Bundle\LocalRecords\Plugins\BaseRecords;
 use eXpansion\Bundle\WidgetBestRecords\Plugins\Gui\BestRecordsWidgetFactory;
 use eXpansion\Framework\Core\Model\UserGroups\Group;
 use eXpansion\Framework\Core\Plugins\StatusAwarePluginInterface;
@@ -79,11 +80,9 @@ class BestRecords implements StatusAwarePluginInterface, RecordsDataListener, Li
     }
 
     /**
-     * Called when local records are loaded.
-     *
-     * @param Record[] $records
+     * @inheritdoc
      */
-    public function onLocalRecordsLoaded($records)
+    public function onLocalRecordsLoaded($records, BaseRecords $baseRecords)
     {
         if (count($records) > 0) {
             $this->widget->setLocalRecord($records[0]);
@@ -94,40 +93,26 @@ class BestRecords implements StatusAwarePluginInterface, RecordsDataListener, Li
     }
 
     /**
-     * Called when a player finishes map for the very first time (basically first record).
-     *
-     * @param Record   $record
-     * @param Record[] $records
-     * @param          $position
+     * @inheritdoc
      */
-    public function onLocalRecordsFirstRecord(Record $record, $records, $position)
+    public function onLocalRecordsFirstRecord(Record $record, $records, $position, BaseRecords $baseRecords)
     {
         $this->widget->setLocalRecord($record);
         $this->widget->update($this->allPlayers);
     }
 
     /**
-     * Called when a player finishes map and does same time as before.
-     *
-     * @param Record   $record
-     * @param Record   $oldRecord
-     * @param Record[] $records
+     * @inheritdoc
      */
-    public function onLocalRecordsSameScore(Record $record, Record $oldRecord, $records)
+    public function onLocalRecordsSameScore(Record $record, Record $oldRecord, $records, BaseRecords $baseRecords)
     {
 
     }
 
     /**
-     * Called when a player finishes map with better time and has better position.
-     *
-     * @param Record   $record
-     * @param Record   $oldRecord
-     * @param Record[] $records
-     * @param int      $position
-     * @param int      $oldPosition
+     * @inheritdoc
      */
-    public function onLocalRecordsBetterPosition(Record $record, Record $oldRecord, $records, $position, $oldPosition)
+    public function onLocalRecordsBetterPosition(Record $record, Record $oldRecord, $records, $position, $oldPosition, BaseRecords $baseRecords)
     {
         if ($position == 1) {
             $this->widget->setLocalRecord($record);
@@ -136,14 +121,9 @@ class BestRecords implements StatusAwarePluginInterface, RecordsDataListener, Li
     }
 
     /**
-     * Called when a player finishes map with better time but keeps same position.
-     *
-     * @param Record   $record
-     * @param Record   $oldRecord
-     * @param Record[] $records
-     * @param          $position
+     * @inheritdoc
      */
-    public function onLocalRecordsSamePosition(Record $record, Record $oldRecord, $records, $position)
+    public function onLocalRecordsSamePosition(Record $record, Record $oldRecord, $records, $position, BaseRecords $baseRecords)
     {
         if ($position == 1) {
             $this->widget->setLocalRecord($record);

--- a/src/eXpansion/Bundle/WidgetBestRecords/Plugins/BestRecords.php
+++ b/src/eXpansion/Bundle/WidgetBestRecords/Plugins/BestRecords.php
@@ -84,6 +84,10 @@ class BestRecords implements StatusAwarePluginInterface, RecordsDataListener, Li
      */
     public function onLocalRecordsLoaded($records, BaseRecords $baseRecords)
     {
+        if (!$this->checkRecordPlugin($baseRecords)) {
+            return;
+        }
+
         if (count($records) > 0) {
             $this->widget->setLocalRecord($records[0]);
         } else {
@@ -97,6 +101,10 @@ class BestRecords implements StatusAwarePluginInterface, RecordsDataListener, Li
      */
     public function onLocalRecordsFirstRecord(Record $record, $records, $position, BaseRecords $baseRecords)
     {
+        if (!$this->checkRecordPlugin($baseRecords)) {
+            return;
+        }
+
         $this->widget->setLocalRecord($record);
         $this->widget->update($this->allPlayers);
     }
@@ -114,6 +122,10 @@ class BestRecords implements StatusAwarePluginInterface, RecordsDataListener, Li
      */
     public function onLocalRecordsBetterPosition(Record $record, Record $oldRecord, $records, $position, $oldPosition, BaseRecords $baseRecords)
     {
+        if (!$this->checkRecordPlugin($baseRecords)) {
+            return;
+        }
+
         if ($position == 1) {
             $this->widget->setLocalRecord($record);
             $this->widget->update($this->allPlayers);
@@ -125,6 +137,10 @@ class BestRecords implements StatusAwarePluginInterface, RecordsDataListener, Li
      */
     public function onLocalRecordsSamePosition(Record $record, Record $oldRecord, $records, $position, BaseRecords $baseRecords)
     {
+        if (!$this->checkRecordPlugin($baseRecords)) {
+            return;
+        }
+
         if ($position == 1) {
             $this->widget->setLocalRecord($record);
             $this->widget->update($this->allPlayers);
@@ -150,5 +166,17 @@ class BestRecords implements StatusAwarePluginInterface, RecordsDataListener, Li
     public function onEndMap(Map $map)
     {
 
+    }
+
+    /**
+     * Check if we can use the data for this plugin.
+     *
+     * @param BaseRecords $baseRecords
+     *
+     * @return bool
+     */
+    protected function checkRecordPlugin(BaseRecords $baseRecords)
+    {
+        return $baseRecords->getRecordsHandler()->getCurrentNbLaps() == 1;
     }
 }

--- a/src/eXpansion/Bundle/WidgetBestRecords/Resources/config/plugins.yml
+++ b/src/eXpansion/Bundle/WidgetBestRecords/Resources/config/plugins.yml
@@ -6,7 +6,7 @@ services:
                 $players: '@expansion.framework.core.user_groups.players'
                 $allPlayers: '@expansion.framework.core.user_groups.all_players'
         tags:
-          - {name: 'expansion.plugin', data_provider: 'expansion.local_records.race'}
+          - {name: 'expansion.plugin', data_provider: 'expansion.local_records.race|expansion.local_records.lap'}
           - {name: 'expansion.plugin', data_provider: 'mp.legacy.map'}
 
     eXpansion\Bundle\WidgetBestRecords\Plugins\Gui\BestRecordsWidgetFactory:

--- a/src/eXpansion/Framework/Core/Plugins/StatusStoredPluginInterface.php
+++ b/src/eXpansion/Framework/Core/Plugins/StatusStoredPluginInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+
+namespace eXpansion\Framework\Core\Plugins;
+
+
+/**
+ * Class StatusStoredPluginInterface
+ *
+ * @package eXpansion\Framework\Core\Plugins;
+ * @author  oliver de Cramer <oliverde8@gmail.com>
+ */
+Interface StatusStoredPluginInterface extends StatusAwarePluginInterface
+{
+    /**
+     * Get the current status of a plugin.
+     *
+     * @return boolean
+     */
+    public function getStatus();
+}

--- a/src/eXpansion/Framework/Core/Plugins/StatusStoredPluginTrait.php
+++ b/src/eXpansion/Framework/Core/Plugins/StatusStoredPluginTrait.php
@@ -1,0 +1,41 @@
+<?php
+
+
+namespace eXpansion\Framework\Core\Plugins;
+
+
+/**
+ * Class StatusStoredPluginTrait
+ *
+ * @package eXpansion\Framework\Core\Plugins;
+ * @author  oliver de Cramer <oliverde8@gmail.com>
+ */
+Trait StatusStoredPluginTrait
+{
+
+    protected $currentStatus = false;
+
+    /**
+     * Set the status of the plugin
+     *
+     * @param boolean $status
+     *
+     * @return null
+     */
+    public function setStatus($status)
+    {
+        $this->currentStatus = $status;
+    }
+
+    /**
+     * Get the current status of a plugin.
+     *
+     * @return boolean
+     */
+    public function getStatus()
+    {
+        return $this->currentStatus;
+    }
+
+
+}

--- a/src/eXpansion/Framework/Core/Services/Application/Dispatcher.php
+++ b/src/eXpansion/Framework/Core/Services/Application/Dispatcher.php
@@ -27,6 +27,8 @@ class Dispatcher implements DispatcherInterface
     /** @var bool  */
     protected $isInitialized = false;
 
+    protected $temporizedEvents = [];
+
     /**
      * Dispatcher constructor.
      *
@@ -47,9 +49,13 @@ class Dispatcher implements DispatcherInterface
         $map = $connection->getCurrentMapInfo();
 
         $this->pluginManager->init($map);
-        $this->dataProviderManager->init($this->pluginManager, $map);
-
+        $this->dataProviderManager->reset($this->pluginManager, $map);
         $this->isInitialized = true;
+
+        foreach ($this->temporizedEvents as $temporizedEvent) {
+            $this->dispatch($temporizedEvent['event'], $temporizedEvent['params']);
+        }
+        $this->temporizedEvents = [];
     }
 
     /**
@@ -91,6 +97,8 @@ class Dispatcher implements DispatcherInterface
 
         if ($this->isInitialized) {
             $this->dataProviderManager->dispatch($event, $params);
+        } else {
+            $this->temporizedEvents[] = ['event' => $event, 'params' => $params];
         }
     }
 }

--- a/src/eXpansion/Framework/Core/Services/DataProviderManager.php
+++ b/src/eXpansion/Framework/Core/Services/DataProviderManager.php
@@ -204,6 +204,11 @@ class DataProviderManager
     {
         $providerId = $this->getCompatibleProviderId($provider, $title, $mode, $script, $map);
 
+        if (empty($providerId)) {
+            var_dump($provider);
+            return;
+        }
+
         /** @var AbstractDataProvider $providerService */
         $providerService = $this->container->get($providerId);
         $pluginService = $this->container->get($pluginId);

--- a/src/eXpansion/Framework/Core/Services/DataProviderManager.php
+++ b/src/eXpansion/Framework/Core/Services/DataProviderManager.php
@@ -69,17 +69,6 @@ class DataProviderManager
     }
 
     /**
-     * Initialize all the providers properly.
-     *
-     * @param PluginManager $pluginManager
-     * @param Map           $map
-     */
-    public function init(PluginManager $pluginManager, Map $map)
-    {
-        $this->reset($pluginManager, $map);
-    }
-
-    /**
      * Reset
      *
      * @param PluginManager $pluginManager
@@ -98,8 +87,8 @@ class DataProviderManager
 
             if ($providerId) {
                 $providerService = $this->container->get($providerId);
-
                 if ($pluginManager->isPluginEnabled($providerId)) {
+
                     foreach ($this->providerListeners[$providerId] as $listener) {
                         $this->enabledProviderListeners[$listener->getEventName()][] = [
                             $providerService,

--- a/src/eXpansion/Framework/Core/Services/DataProviderManager.php
+++ b/src/eXpansion/Framework/Core/Services/DataProviderManager.php
@@ -194,7 +194,6 @@ class DataProviderManager
         $providerId = $this->getCompatibleProviderId($provider, $title, $mode, $script, $map);
 
         if (empty($providerId)) {
-            var_dump($provider);
             return;
         }
 

--- a/src/eXpansion/Framework/Core/Services/PluginManager.php
+++ b/src/eXpansion/Framework/Core/Services/PluginManager.php
@@ -172,9 +172,9 @@ class PluginManager
             $dataProviders = explode("|", $dataProvider);
             $foundOne = false;
 
-            foreach ($dataProviders as $dataProvider) {
-                $providerId = $this->dataProviderManager->getCompatibleProviderId($dataProvider, $title, $mode, $script, $map);
-                if (is_null($providerId) || !isset($enabledPlugins[$providerId])) {
+            foreach ($dataProviders as $provider) {
+                $providerId = $this->dataProviderManager->getCompatibleProviderId($provider, $title, $mode, $script, $map);
+                if (!is_null($providerId) && isset($enabledPlugins[$providerId])) {
                     // Either there are no data providers compatible or the only one compatible
                     $foundOne = true;
                     break;
@@ -256,7 +256,7 @@ class PluginManager
         foreach ($plugin->getDataProviders() as $provider) {
             $dataProviders = explode("|", $provider);
             foreach ($dataProviders as $dataProvider) {
-                $this->dataProviderManager->deletePlugin($provider, $plugin->getPluginId());
+                $this->dataProviderManager->deletePlugin($dataProvider, $plugin->getPluginId());
             }
         }
 

--- a/src/eXpansion/Framework/Core/Services/PluginManager.php
+++ b/src/eXpansion/Framework/Core/Services/PluginManager.php
@@ -169,10 +169,19 @@ class PluginManager
 
         // Now check for data providers.
         foreach ($plugin->getDataProviders() as $dataProvider) {
-            $providerId = $this->dataProviderManager->getCompatibleProviderId($dataProvider, $title, $mode, $script, $map);
+            $dataProviders = explode("|", $dataProvider);
+            $foundOne = false;
 
-            if (is_null($providerId) || !isset($enabledPlugins[$providerId])) {
-                // Either there are no data providers compatible or the only one compatible
+            foreach ($dataProviders as $dataProvider) {
+                $providerId = $this->dataProviderManager->getCompatibleProviderId($dataProvider, $title, $mode, $script, $map);
+                if (is_null($providerId) || !isset($enabledPlugins[$providerId])) {
+                    // Either there are no data providers compatible or the only one compatible
+                    $foundOne = true;
+                    break;
+                }
+            }
+
+            if (!$foundOne) {
                 return false;
             }
         }
@@ -220,7 +229,10 @@ class PluginManager
         }
 
         foreach ($plugin->getDataProviders() as $provider) {
-            $this->dataProviderManager->registerPlugin($provider, $plugin->getPluginId(), $title, $mode, $script, $map);
+            $dataProviders = explode("|", $provider);
+            foreach ($dataProviders as $dataProvider) {
+                $this->dataProviderManager->registerPlugin($dataProvider, $plugin->getPluginId(), $title, $mode, $script, $map);
+            }
         }
 
         $this->enabledPlugins[$plugin->getPluginId()] = $plugin;
@@ -242,7 +254,10 @@ class PluginManager
         $pluginService = $this->container->get($plugin->getPluginId());
 
         foreach ($plugin->getDataProviders() as $provider) {
-            $this->dataProviderManager->deletePlugin($provider, $plugin->getPluginId());
+            $dataProviders = explode("|", $provider);
+            foreach ($dataProviders as $dataProvider) {
+                $this->dataProviderManager->deletePlugin($provider, $plugin->getPluginId());
+            }
         }
 
         if (isset($this->enabledPlugins[$plugin->getPluginId()])) {

--- a/tests/eXpansion/Bundle/LocalRecords/DataProviders/RecordsDataProviderTest.php
+++ b/tests/eXpansion/Bundle/LocalRecords/DataProviders/RecordsDataProviderTest.php
@@ -3,6 +3,7 @@
 namespace Tests\eXpansion\Bundle\LocalRecords\DataProviders;
 
 use eXpansion\Bundle\LocalRecords\DataProviders\RecordsDataProvider;
+use eXpansion\Bundle\LocalRecords\Plugins\BaseRecords;
 use eXpansion\Bundle\LocalRecords\Services\RecordHandler;
 
 class RecordsDataProviderTest extends \PHPUnit_Framework_TestCase
@@ -10,11 +11,15 @@ class RecordsDataProviderTest extends \PHPUnit_Framework_TestCase
     /** @var  RecordsDataProvider */
     protected $provider;
 
+    /** @var \PHPUnit_Framework_MockObject_MockObject */
+    protected $mockPlugin;
+
     protected function setUp()
     {
         parent::setUp();
 
         $this->provider =  new RecordsDataProvider();
+        $this->mockPlugin = $this->getMockBuilder(BaseRecords::class)->disableOriginalConstructor()->getMock();
     }
 
     public function testFirstRecord()
@@ -22,6 +27,7 @@ class RecordsDataProviderTest extends \PHPUnit_Framework_TestCase
         $this->provider->onRecordsLoaded(
             [
                 RecordHandler::COL_RECORDS => [],
+                RecordHandler::COL_PLUGIN => $this->mockPlugin,
             ]
         );
         $this->provider->onFirstRecord(
@@ -29,6 +35,7 @@ class RecordsDataProviderTest extends \PHPUnit_Framework_TestCase
                 RecordHandler::COL_RECORD => [],
                 RecordHandler::COL_RECORDS => [],
                 RecordHandler::COL_POS => 1,
+                RecordHandler::COL_PLUGIN => $this->mockPlugin,
             ]
         );
         $this->provider->onSameScore(
@@ -36,6 +43,7 @@ class RecordsDataProviderTest extends \PHPUnit_Framework_TestCase
                 RecordHandler::COL_RECORD => [],
                 RecordHandler::COL_OLD_RECORD => [],
                 RecordHandler::COL_RECORDS => [],
+                RecordHandler::COL_PLUGIN => $this->mockPlugin,
             ]
         );
         $this->provider->onBetterPosition(
@@ -45,6 +53,7 @@ class RecordsDataProviderTest extends \PHPUnit_Framework_TestCase
                 RecordHandler::COL_RECORDS => [],
                 RecordHandler::COL_POS => 1,
                 RecordHandler::COL_OLD_POS => 2,
+                RecordHandler::COL_PLUGIN => $this->mockPlugin,
             ]
         );
         $this->provider->onSamePosition(
@@ -53,6 +62,7 @@ class RecordsDataProviderTest extends \PHPUnit_Framework_TestCase
                 RecordHandler::COL_OLD_RECORD => [],
                 RecordHandler::COL_RECORDS => [],
                 RecordHandler::COL_POS => 1,
+                RecordHandler::COL_PLUGIN => $this->mockPlugin,
             ]
         );
     }

--- a/tests/eXpansion/Bundle/LocalRecords/Plugins/ChatNotificationTest.php
+++ b/tests/eXpansion/Bundle/LocalRecords/Plugins/ChatNotificationTest.php
@@ -3,6 +3,7 @@
 namespace Tests\eXpansion\Bundle\LocalRecords\Plugins;
 
 use eXpansion\Bundle\LocalRecords\Model\Record;
+use eXpansion\Bundle\LocalRecords\Plugins\BaseRecords;
 use eXpansion\Bundle\LocalRecords\Plugins\ChatNotification;
 use eXpansion\Framework\Config\Model\ConfigInterface;
 use eXpansion\Framework\Config\Model\IntegerConfig;
@@ -26,6 +27,9 @@ class ChatNotificationTest extends \PHPUnit_Framework_TestCase
     /** @var \PHPUnit_Framework_MockObject_MockObject */
     protected $timeFormatter;
 
+    /** @var \PHPUnit_Framework_MockObject_MockObject */
+    protected $mockBasePlugin;
+
     protected function setUp()
     {
         parent::setUp();
@@ -47,6 +51,7 @@ class ChatNotificationTest extends \PHPUnit_Framework_TestCase
             ->disableOriginalConstructor()->getMock();
 
         $this->timeFormatter = $this->getMockBuilder(Time::class)->getMock();
+        $this->mockBasePlugin = $this->getMockBuilder(BaseRecords::class)->disableOriginalConstructor()->getMock();
     }
 
     /**
@@ -95,7 +100,7 @@ class ChatNotificationTest extends \PHPUnit_Framework_TestCase
             $this->getRecord('toto-4', 40),
         ];
 
-        $cnotificaiton->onLocalRecordsLoaded($records);
+        $cnotificaiton->onLocalRecordsLoaded($records, $this->mockBasePlugin);
     }
 
     public function testFirstRecord() {
@@ -110,7 +115,7 @@ class ChatNotificationTest extends \PHPUnit_Framework_TestCase
                 ['%nickname%' => 'toto - nick', '%score%' => null, '%position%' => 1]
             );
 
-        $cnotificaiton->onLocalRecordsFirstRecord($this->getRecord('toto', 10), [], 1);
+        $cnotificaiton->onLocalRecordsFirstRecord($this->getRecord('toto', 10), [], 1, $this->mockBasePlugin);
     }
 
     public function testBestFirstRecord() {
@@ -130,7 +135,9 @@ class ChatNotificationTest extends \PHPUnit_Framework_TestCase
             $this->getRecord('toto', 10),
             [],
             1,
-            null);
+            null,
+            $this->mockBasePlugin
+        );
     }
 
     public function testBetterTop1() {
@@ -150,7 +157,9 @@ class ChatNotificationTest extends \PHPUnit_Framework_TestCase
             $this->getRecord('toto', 8),
             [],
             1,
-            2);
+            2,
+            $this->mockBasePlugin
+        );
     }
 
     public function testBetterTop5() {
@@ -170,7 +179,9 @@ class ChatNotificationTest extends \PHPUnit_Framework_TestCase
             $this->getRecord('toto', 8),
             [],
             4,
-            7);
+            7,
+            $this->mockBasePlugin
+        );
     }
     public function testBetterAny() {
         $cnotificaiton = $this->getChatNotification();
@@ -189,7 +200,9 @@ class ChatNotificationTest extends \PHPUnit_Framework_TestCase
             $this->getRecord('toto', 8),
             [],
             8,
-            10);
+            10,
+            $this->mockBasePlugin
+        );
     }
     public function testBetterAnyNew() {
         $cnotificaiton = $this->getChatNotification();
@@ -208,7 +221,9 @@ class ChatNotificationTest extends \PHPUnit_Framework_TestCase
             $this->getRecord('toto', 8),
             [],
             8,
-            null);
+            null,
+            $this->mockBasePlugin
+        );
     }
 
     public function testBetterAnyBad() {
@@ -228,7 +243,9 @@ class ChatNotificationTest extends \PHPUnit_Framework_TestCase
             $this->getRecord('toto', 8),
             [],
             12,
-            30);
+            30,
+            $this->mockBasePlugin
+        );
     }
 
     public function testSamePositionFirst()
@@ -248,7 +265,9 @@ class ChatNotificationTest extends \PHPUnit_Framework_TestCase
             $this->getRecord('toto', 10),
             $this->getRecord('toto', 8),
             [],
-            1);
+            1,
+            $this->mockBasePlugin
+        );
     }
 
     public function testSamePositionTop5()
@@ -268,7 +287,9 @@ class ChatNotificationTest extends \PHPUnit_Framework_TestCase
             $this->getRecord('toto', 10),
             $this->getRecord('toto', 8),
             [],
-            5);
+            5,
+            $this->mockBasePlugin
+        );
     }
 
 
@@ -289,7 +310,9 @@ class ChatNotificationTest extends \PHPUnit_Framework_TestCase
             $this->getRecord('toto', 10),
             $this->getRecord('toto', 8),
             [],
-            8);
+            8,
+            $this->mockBasePlugin
+        );
     }
 
 
@@ -310,7 +333,8 @@ class ChatNotificationTest extends \PHPUnit_Framework_TestCase
             $this->getRecord('toto', 10),
             $this->getRecord('toto', 8),
             [],
-            30
+            30,
+            $this->mockBasePlugin
         );
     }
 
@@ -332,7 +356,9 @@ class ChatNotificationTest extends \PHPUnit_Framework_TestCase
             $this->getRecord('toto', 10),
             $this->getRecord('toto', 8),
             [],
-            30);
+            30,
+            $this->mockBasePlugin
+        );
     }
 
     public function testByShort()
@@ -353,15 +379,22 @@ class ChatNotificationTest extends \PHPUnit_Framework_TestCase
             $this->getRecord('toto', 10),
             $this->getRecord('toto', 8),
             [],
-            30);
+            30,
+            $this->mockBasePlugin
+        );
     }
 
     public function testEmptyMethods()
     {
         $cnotificaiton = $this->getChatNotification();
 
-        $cnotificaiton->onLocalRecordsLoaded([]);
-        $cnotificaiton->onLocalRecordsSameScore($this->getRecord('toto', 10), $this->getRecord('toto', 8), []);
+        $cnotificaiton->onLocalRecordsLoaded([], $this->mockBasePlugin);
+        $cnotificaiton->onLocalRecordsSameScore(
+            $this->getRecord('toto', 10),
+            $this->getRecord('toto', 8),
+            [],
+            $this->mockBasePlugin
+        );
     }
 
     /**

--- a/tests/eXpansion/Framework/Core/Services/DataProviderManagerTest.php
+++ b/tests/eXpansion/Framework/Core/Services/DataProviderManagerTest.php
@@ -28,6 +28,7 @@ class DataProviderManagerTest extends TestCore
 
     protected $mockGameDataStorage;
 
+    /** @var DataProviderManager */
     protected $dataProviderManager;
 
     protected function setUp()
@@ -176,7 +177,7 @@ class DataProviderManagerTest extends TestCore
         $dataProviderMock2 = $this->container->get('dp1-2');
         $dataProviderMock2->expects($this->never())->method('onPlayerChat');
 
-        $dataProviderManager->init($pManagerMock, new Map());
+        $dataProviderManager->reset($pManagerMock, new Map());
         $dataProviderManager->dispatch('onPlayerChat', ['test', 'test2', false]);
     }
 


### PR DESCRIPTION
* Allow listening to multiple data providers at the time (so widgets can listen to race & laps listeners)
* Updated widgets to handle the race & laps records
* Update Records window to show race & lap records
* Fixed issue with lost events at eXpansion startup